### PR TITLE
Fix typos in cryptography section

### DIFF
--- a/src/cryptography/digital_signatures/introduction_schnorr_signatures.md
+++ b/src/cryptography/digital_signatures/introduction_schnorr_signatures.md
@@ -156,7 +156,7 @@ We can show that leaving off the nonce is indeed highly insecure:
 #### ECDH
 
 How do parties that want to communicate securely generate a shared secret for encrypting messages? One way is called
-the Elliptic Curve Diffie-Hellmam exchange (ECDH), which is a simple method for doing just this.
+the Elliptic Curve Diffie-Hellman exchange (ECDH), which is a simple method for doing just this.
 
 ECDH is used in many places, including the Lightning Network during channel negotiation [[3]].
 

--- a/src/cryptography/scriptless-scripts/PITCHME.md
+++ b/src/cryptography/scriptless-scripts/PITCHME.md
@@ -27,7 +27,7 @@
 
 The benefit of Scriptless Scripts are functionality, privacy and efficiency. [[1]](https://medium.com/blockchain-capital/crypto-innovation-spotlight-2-scriptless-scripts-306c4eb6b3a8)  
 
-- Functionality: Scriptless Scripts may increase the range and complexity of smart contracts. Scriptless scripts move the specification and execution of smart contractions from the network to a discussion that only involves the participants of the smart contract. 
+- Functionality: Scriptless Scripts may increase the range and complexity of smart contracts. Scriptless scripts move the specification and execution of smart contracts from the network to a discussion that only involves the participants of the smart contract.
 - Privacy: Moving the specification and execution of smart contracts from on-chain to off-chain increases privacy. 
 - Efficiency: Scriptless Scripts minimize the amount of data that requires verification and storage on-chain.  
 
@@ -72,7 +72,7 @@ $$
 
 ## Schnorr multi-signatures = Scriptless Scripts
 
--a mulitsig has multiple participants that produce a signature. Every participant might product a separate signature and concatenate them forming a mulitsig. 
+-a multisig has multiple participants that produce a signature. Every participant might product a separate signature and concatenate them forming a multisig.
 
 $$
   s=Σs(i)
@@ -86,17 +86,17 @@ $$
 
 ## Adaptor Signatures 
 
-- This mulitsig protocol can be modified to produce an adaptor signature, which serves as the building block for all scriptless script functions. [[5]](https://joinmarket.me/blog/blog/flipping-the-scriptless-script-on-schnorr/) 
+- This multisig protocol can be modified to produce an adaptor signature, which serves as the building block for all scriptless script functions. [[5]](https://joinmarket.me/blog/blog/flipping-the-scriptless-script-on-schnorr/) 
 
 - Instead of functioning as full valid signature on a message with a key, an adaptor signature is a promise that a signature agreed to be published, will reveal a secret. 
 
 - This concept is similar to that of atomic swaps, however no scrips are implemented. Since this is elliptic curve cryptography, there is only scalar multiplication of elliptic curve points. Fortunately, like a hash function, elliptic curve function in one way, so an elliptic curve point (*T*), can simply be shared and the secret will be it's corresponding private key.  
 
-- If two parties are considered: rather than providing their nonce *R* in the mulitsig protocol, a blinding factor, taken as an elliptic curve point *T* is conceived and sent in addition to *R* (ie. *R+T*). So it can be seen that *R* is not blinded, it has instead been offset by the secret value *T*. 
+- If two parties are considered: rather than providing their nonce *R* in the multisig protocol, a blinding factor, taken as an elliptic curve point *T* is conceived and sent in addition to *R* (ie. *R+T*). So it can be seen that *R* is not blinded, it has instead been offset by the secret value *T*. 
 
 +++
 
-Here, the Schnorr mulitsig construction is modified such that the first party generates 
+Here, the Schnorr multisig construction is modified such that the first party generates
 
 $$
 T=tG, R=rG
@@ -201,7 +201,7 @@ By attaching auxiliary proofs one can derive an adaptor signature to translate c
 
 - Mimblewimble is a block chain design. Built similarly to Bitcoin, every transaction has inputs and outputs. Each input and output has a confidential transaction commitment. 
 -Confidential commitments have an interesting property where in a valid balanced transaction one can subtract the input from the output commitments, ensuring that all of the values of the Pedersen values balance out. 
--Taking the difference of these inputs and outputs results in the mulitsig key of the owners of every output and every input in the transaction. This is referred to as the kernel.
+-Taking the difference of these inputs and outputs results in the multisig key of the owners of every output and every input in the transaction. This is referred to as the kernel.
 - Mimblewimble blocks will only have a list of new inputs, a list of new outputs and a list of signatures which are created from the aforementioned excess value. [[7]](https://www.cryptocompare.com/coins/guides/what-is-mimblewimble/)
 - Since the values are homomorphically encrypted, nodes can verify that no coin are being created or destroyed. 
 

--- a/src/cryptography/scriptless-scripts/introduction-to-scriptless-scripts.md
+++ b/src/cryptography/scriptless-scripts/introduction-to-scriptless-scripts.md
@@ -39,7 +39,7 @@ The benefits of Scriptless Scripts are functionality, privacy and efficiency.
 
 With regard to functionality, Scriptless Scripts are said to increase the range and complexity of smart contracts. 
 Currently, as within Bitcoin Script, limitations stem from the number of ```OP_CODES``` that have been enabled by the 
-network. Scriptless Scripts move the specification and execution of smart contractions from the network to a discussion 
+network. Scriptless Scripts move the specification and execution of smart contracts from the network to a discussion
 that only involves the participants of the smart contract. 
 
 ### Privacy
@@ -99,14 +99,14 @@ thus less useful [[2]].
 
 ## Schnorr Multi-signatures
 
-A multi-signature (mulitsig) has multiple participants that produce a signature. Every participant might produce a 
-separate signature and concatenate them, forming a mulitsig. 
+A multi-signature (multisig) has multiple participants that produce a signature. Every participant might produce a 
+separate signature and concatenate them, forming a multisig.
 
 With Schnorr Signatures, one can have a single public key, which is the sum of many different people's public keys. The 
 resulting key is one against which signatures will be verifiable [[5]].
 
-The formulation of a mulitsig involves taking the sum of all components; thus all nonces and $s$ values result in the 
-formulation of a mulitsig [[4]]:
+The formulation of a multisig involves taking the sum of all components; thus all nonces and $s$ values result in the 
+formulation of a multisig [[4]]:
 $$
 s=\sum s(i)
 $$
@@ -118,7 +118,7 @@ number of participants involved or the original public keys.
 
 ## Adaptor Signatures  
 
-This mulitsig protocol can be modified to produce an adaptor signature, which serves as the building block for all 
+This multisig protocol can be modified to produce an adaptor signature, which serves as the building block for all
 Scriptless Script functions [[5]]. 
 
 Instead of functioning as a full valid signature on a message with a key, an adaptor signature is a promise that a 
@@ -129,12 +129,12 @@ cryptography, there is only scalar multiplication of elliptic curve points. Fort
 elliptic curves function in one way, so an elliptic curve point ($T$), can simply be shared and the secret will be its 
 corresponding private key.  
 
-If two parties are considered, rather than providing their nonce $R$ in the mulitsig protocol, a blinding factor, taken 
+If two parties are considered, rather than providing their nonce $R$ in the multisig protocol, a blinding factor, taken 
 as an elliptic curve point $T$, is conceived and sent in addition to $R$ (i.e. $R+T$). It can therefore be seen that 
 $R$ is not 
 blinded; it has instead been offset by the secret value $T$. 
 
-Here, the Schnorr mulitsig construction is modified such that the first party generates 
+Here, the Schnorr multisig construction is modified such that the first party generates
 $$
 T=tG, R=rG
 $$
@@ -221,7 +221,7 @@ and then reveal the same preimage on both sides. Once Alice knows the preimage, 
 then copies it off one chain to the other chain to take his coins. 
 
 Using adaptor signatures, the same result can be achieved through simpler means. In this case, both Alice and Bob put 
-up their coins on two of two outputs on each blockchain. They sign the mulitsig protocols in parallel, where Bob then 
+up their coins on two of two outputs on each blockchain. They sign the multisig protocols in parallel, where Bob then
 gives Alice the adaptor signatures for each side using the same value $T$ . This means that for Bob to take his coins, 
 he needs to reveal $t$; and for Alice to take her coins, she needs to reveal $T$. Bob then replaces one of the 
 signatures and publishes $t$, taking his coins. Alice computes $t$  from the final signature, visible on the blockchain, 
@@ -247,7 +247,7 @@ As previously stated, Mimblewimble is a blockchain design. Built similarly to Bi
 outputs. Each input and output has a confidential transaction commitment. Confidential commitments have an interesting 
 property where, in a valid balanced transaction, one can subtract the input from the output commitments, ensuring that 
 all of the values of the Pedersen values balance out. Taking the difference of these inputs and outputs results in the 
-mulitsig key of the owners of every output and every input in the transaction. This is referred to as the kernel.
+multisig key of the owners of every output and every input in the transaction. This is referred to as the kernel.
 
 Mimblewimble blocks will only have a list of new inputs, new outputs and signatures that are created 
 from the aforementioned excess value [[7]].


### PR DESCRIPTION
* Hellmam -> Hellman
* contractions -> contracts
* mulitsig -> multisig