### PR TITLE
fixed wrong equation

### DIFF
--- a/src/cryptography/bulletproofs-protocols/MainReport.md
+++ b/src/cryptography/bulletproofs-protocols/MainReport.md
@@ -351,7 +351,7 @@ $$
 
 <br>
 
-Commitment $ P = L \cdot R $ can then further be sliced as follows:
+Commitment $ P $ can then further be sliced into $ L $ and $ R $ as follows:
 
 $$
 \begin{aligned} 


### PR DESCRIPTION
obviously P can not be L · R because that would require <a_[:n'],b_[n':]> + <a_[n':],b_[:n']> = <a,b>
counterexample:
a=(3,7,5,6), b=(2,3,4,1)
<a,b> = 6+21+20+6 = 53
but 
<a_[:n'],b_[n':]> = <(3,7),(4,1)> = 12 + 7 = 19
<a_[n':],b_[:n']> = <(5,6),(2,3)> = 10 + 18 = 28
and 19+28 = 47 != 53