### PR TITLE
Update build instructions and add Ruby 3 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'jekyll-redirect-from'
 group :jekyll_plugins do
    gem "jekyll-spaceship"
 end
+gem "webrick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
 
 PLATFORMS
   x86_64-darwin-19
@@ -90,6 +91,7 @@ DEPENDENCIES
   jekyll-sitemap
   jekyll-spaceship
   jekyll-tagging
+  webrick
 
 BUNDLED WITH
    2.2.26

--- a/README.md
+++ b/README.md
@@ -9,4 +9,9 @@ To build and serve the site locally (assuming an Ubuntu operating system):
 - Serve the site: `bundle exec jekyll serve`
 - View the site in a browser using the link provided in your terminal: http://localhost:4000
 
+For more convenient development, consider enabling live reloading and incremental builds. To do so, use this command instead
+to serve the site: `bundle exec jekyll serve -l --incremental`
+
+This will speed up the build process, and will also reload your browser automatically when changes are saved.
+
 Production builds use [GitHub Pages](https://pages.github.com/) via [GitHub Actions](.github/workflows/github-pages.yml).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Tari Labs University
 
+To build and serve the site locally (assuming an Ubuntu operating system):
+- Install at least [Ruby 2.7](https://www.ruby-lang.org/en/downloads/) using your preferred method.
+- Install build tools: `sudo apt install build-essential`
+- Install the bundler: `gem install bundler`
+- Navigate to the repository directory
+- Install dependencies: `bundle install`
+- Serve the site: `bundle exec jekyll serve`
+- View the site in a browser using the link provided in your terminal: `http://localhost:4000`
 
-
-* * *
-
-### Deployment
-
-To run the theme locally, navigate to the theme directory and run `bundle install` to install the dependencies, then run `bundle exec jekyll serve` to start the Jekyll server.
-
-I would recommend checking the [Deployment Methods](https://jekyllrb.com/docs/deployment-methods/) page on the Jekyll website.
+Production builds use [GitHub Pages](https://pages.github.com/) via [GitHub Actions](.github/workflows/github-pages.yml).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ To build and serve the site locally (assuming an Ubuntu operating system):
 - Navigate to the repository directory
 - Install dependencies: `bundle install`
 - Serve the site: `bundle exec jekyll serve`
-- View the site in a browser using the link provided in your terminal: `http://localhost:4000`
+- View the site in a browser using the link provided in your terminal: http://localhost:4000
 
 Production builds use [GitHub Pages](https://pages.github.com/) via [GitHub Actions](.github/workflows/github-pages.yml).


### PR DESCRIPTION
Local builds fail using Ruby 3, since the `webrick` gem is apparently [no longer bundled](https://github.com/jekyll/jekyll/issues/8523) by default. Additionally, the local build instructions provided by this repository aren't very detailed.

This pull request does two things:
- Adds `webrick` to the `Gemfile` so it's specifically installed if not already bundled, which effectively adds Ruby 3 support
- Updates the build instructions to be more complete

These changes have been tested on both Ruby 3.0.2 and Ruby 2.7.6 successfully. They have not been specifically tested on the GitHub Actions deployment process.

Fixes [issue 304](https://github.com/tari-labs/tari-university/issues/304).